### PR TITLE
Precompiles code to commonjs when published

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bower_components
 build
 coverage
 node_modules
+/lib

--- a/package.json
+++ b/package.json
@@ -8,12 +8,16 @@
     "node": ">=0.12.0",
     "npm": ">=3.0.0"
   },
-  "main": "src/Anim.js",
+	"jsnext:main": "src/Anim.js",
+  "main": "lib/Anim.js",
   "files": [
+		"lib",
     "src/**/*.js",
     "test/**/*.js"
   ],
   "scripts": {
+		"compile": "babel --presets es2015 -d lib/ src/",
+		"prepublish": "npm run compile",
     "test": "gulp test"
   },
   "keywords": [
@@ -24,6 +28,8 @@
     "metal-dom": "^1.0.0-rc.2"
   },
   "devDependencies": {
+		"babel-cli": "^6.4.5",
+		"babel-preset-es2015": "^6.3.13",
     "gulp": "^3.8.11",
     "gulp-metal": "^1.0.0"
   }


### PR DESCRIPTION
I added metal-anim to metal-css-transitions and needed the compiled version of metal-anim. Let me know if this is okay.

Thanks!
